### PR TITLE
Fix dark theme about overlay

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1372,3 +1372,8 @@ body.keyboard-open .claude-messages {
 [data-theme="dark"] .about-container * {
   color: var(--text-color) !important;
 }
+
+/* Provide a darker background for the about section in dark mode */
+[data-theme="dark"] .about-container {
+  background-color: #374151;
+}


### PR DESCRIPTION
## Summary
- improve dark theme styling for the mobile "About This Tool" overlay

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*