### PR TITLE
Fix about section background for dark mode

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1361,6 +1361,16 @@ body.keyboard-open .claude-messages {
   padding-bottom: 80px; /* Reduced padding when keyboard is open */
 }
 
+/* Style for the about section */
+.about-container {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
 /* Dark mode adjustments */
 [data-theme="dark"] body.keyboard-open .claude-input-area {
   background-color: #1f2937;

--- a/search.html
+++ b/search.html
@@ -73,7 +73,7 @@ custom_class: search-page
   <!-- Help Section (hidden on mobile by default) -->
 <!-- Help Section - Updated About Content -->
 <div id="infoSection" class="info-section">
-  <div class="about-container" style="max-width: 700px; margin: 0 auto; padding: 1.5rem; background-color: #f9f9f9; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+  <div class="about-container">
     <h2 class="content-section-header" data-i18n="about-tool" style="color: #641c14; border-bottom: 2px solid #641c14; padding-bottom: 10px; margin-bottom: 20px; font-size: 1.5rem;">About This Tool</h2>
     
     <p data-i18n="tool-description" style="line-height: 1.6; margin-bottom: 16px;">


### PR DESCRIPTION
## Summary
- remove inline background color from the about container in `search.html`
- add CSS rule for `.about-container` styles so dark-mode styles apply correctly

## Testing
- `bundle exec jekyll build` *(fails: command not found)*