### PR TITLE
Fix dark mode for about disclaimer

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1361,6 +1361,26 @@ body.keyboard-open .claude-messages {
   padding-bottom: 80px; /* Reduced padding when keyboard is open */
 }
 
+/* Style for the about section */
+.about-container {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* Styling for the disclaimer note within the about section */
+.about-container .disclaimer {
+  background-color: #f0f0f0;
+  padding: 12px;
+  border-radius: 6px;
+  line-height: 1.6;
+  font-size: 0.9rem;
+  margin-top: 24px;
+}
+
 /* Dark mode adjustments */
 [data-theme="dark"] body.keyboard-open .claude-input-area {
   background-color: #1f2937;
@@ -1376,4 +1396,9 @@ body.keyboard-open .claude-messages {
 /* Provide a darker background for the about section in dark mode */
 [data-theme="dark"] .about-container {
   background-color: #374151;
+}
+
+/* Dark mode background for the disclaimer note */
+[data-theme="dark"] .about-container .disclaimer {
+  background-color: #4b5563;
 }

--- a/search.html
+++ b/search.html
@@ -73,7 +73,7 @@ custom_class: search-page
   <!-- Help Section (hidden on mobile by default) -->
 <!-- Help Section - Updated About Content -->
 <div id="infoSection" class="info-section">
-  <div class="about-container" style="max-width: 700px; margin: 0 auto; padding: 1.5rem; background-color: #f9f9f9; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+  <div class="about-container">
     <h2 class="content-section-header" data-i18n="about-tool" style="color: #641c14; border-bottom: 2px solid #641c14; padding-bottom: 10px; margin-bottom: 20px; font-size: 1.5rem;">About This Tool</h2>
     
     <p data-i18n="tool-description" style="line-height: 1.6; margin-bottom: 16px;">
@@ -92,7 +92,7 @@ custom_class: search-page
       Each response includes links to the corresponding sermon videos with timestamps, allowing you to watch the original content in its full context. This tool is provided for personal study purposes only.
     </p>
     
-    <p data-i18n="disclaimer" style="background-color: #f0f0f0; padding: 12px; border-radius: 6px; line-height: 1.6; font-size: 0.9rem; margin-top: 24px;">
+    <p data-i18n="disclaimer" class="disclaimer">
       <em>Note: This is an independent project created to facilitate sermon research and is not officially affiliated with or endorsed by Fellowship Baptist Church. All sermon content remains the intellectual property of the respective speakers.</em>
     </p>
   </div>


### PR DESCRIPTION
## Summary
- fix markup for the disclaimer note in the About pop‑up
- style the disclaimer in CSS and add dark mode variant

## Testing
- `bundle exec jekyll build` *(fails: command not found)*