### PR TITLE
Fix dark mode disclaimer contrast

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1387,3 +1387,9 @@ body.keyboard-open .claude-messages {
 [data-theme="dark"] .about-container {
   background-color: #374151;
 }
+
+/* Improve disclaimer contrast in dark theme */
+[data-theme="dark"] p[data-i18n="disclaimer"] {
+  background-color: #4a5568 !important; /* dark grey background */
+  color: var(--text-color) !important;
+}


### PR DESCRIPTION
## Summary
- tweak CSS to darken disclaimer background in dark mode

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*