### PR TITLE
Fix dark mode overlay text

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -38,6 +38,9 @@
   /* Brighter text colors for better contrast */
   --text-color: #f5f5f5;
   --text-light: #d1d5db;
+  /* Ensure components using legacy variables also switch to light text */
+  --color-text: #f5f5f5;
+  --color-text-light: #d1d5db;
   --border-color: #374151;
   --shadow-color: rgba(0, 0, 0, 0.3);
 }
@@ -858,6 +861,7 @@ a:focus, button:focus, input:focus, select:focus, textarea:focus {
   flex: 1;
   overflow-y: auto;
   padding: 1.5rem;
+  color: var(--text-color);
 }
 
 /* Video container in overlay */


### PR DESCRIPTION
## Summary
- address readability in dark mode
- make overlay body use the text-color variable
- override legacy `--color-text` variables in dark theme

## Testing
- `git status --short`